### PR TITLE
Fix eot file is empty after generation (0 bytes)

### DIFF
--- a/fontfacegen.js
+++ b/fontfacegen.js
@@ -276,12 +276,16 @@ fontforge = function() {
 ttf2eot = function(source, dest) {
     var command, result, success;
 
-    command = [globals.ttf2eot, quote(source), '>', quote(dest)].join(' ');
+    command = [globals.ttf2eot, quote(source)].join(' ');
 
     result = exec(command);
     success = (result.status == 0);
 
-    if (! success) {
+    if (success) {
+        fs.writeFile(dest, result.stdout, function (err) {
+          if (err) return console.error(err);
+        });
+    } else {
         throw new FontFaceException(
             'ttf2eot exited with error code: ' + result.code + '\n' +
             result.stdout.trim() + '\n' +


### PR DESCRIPTION
On linux redirect symbol in `exec()` does not seem to work since `exec` itself captures stdout