### PR TITLE
Add subset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Path to the font files relative to the css generated.
 
 Default = ''
 
+### subset
+
+A string or array with the characters desired to be included inside the generated fonts
+
+Default = null
+
 ### collate:
 
 Append the source filename to the destination directory in order to collate generated fonts into separate directories.
@@ -119,6 +125,7 @@ Note: If present, the json config file must be valid json.
                 dest: dest,
                 css_fontpath: '../fonts/',
                 embed: ['ttf'],
+                subset: 'abcdef',
                 collate: true
             });
         }

--- a/lib/fontfacegen.js
+++ b/lib/fontfacegen.js
@@ -29,7 +29,7 @@ module.exports = function(options) {
         mkdirp(path.dirname(config.scss));   
     }
 
-    ttf(config.source, config.ttf, config.name);
+    ttf(config.source, config.ttf, config.name, config); // TODO: better options handling
     ttf2eot(config.ttf, config.eot);
     ttf2svg(config.ttf, config.svg, config.name);
     ttf2woff(config.ttf, config.woff);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,6 +35,17 @@ function removeNewLines(buffer) {
   return buffer.toString().replace(/\r?\n|\r/g);
 }
 
+function uniqueChars(subset) {
+  return (typeof subset === 'string' ? subset.split('') : subset)
+    .filter(function(ch, i, chars) {
+      return chars.indexOf(ch) === i;
+    });
+}
+
+function charToHex(ch) {
+  return ch.charCodeAt(0).toString(16);
+}
+
 var _isLinux = os.type().toLowerCase() == "linux";
 
 function isLinux() {
@@ -46,4 +57,6 @@ module.exports.quote = quote;
 module.exports.merge = merge;
 module.exports.trim = trim;
 module.exports.removeNewLines = removeNewLines;
+module.exports.uniqueChars = uniqueChars;
+module.exports.charToHex = charToHex;
 module.exports.isLinux = isLinux;

--- a/lib/ttf.js
+++ b/lib/ttf.js
@@ -1,11 +1,27 @@
 'use strict';
 
 var fontforge = require('./fontforge.js');
+var uniqueChars = require('./helpers.js').uniqueChars;
+var charToHex = require('./helpers.js').charToHex;
 
-module.exports = function(source, target, name) {
+module.exports = function(source, target, name, opts) {
+    opts = opts || {};
+
+    var subset = opts.subset;
+    var subsetCmd = '';
+
+    if (subset) {
+        subsetCmd = uniqueChars(subset)
+        .map(function (ch) {
+            return 'SelectFewer(0u' + charToHex(ch) + ');';
+        })
+        .join('');
+        subsetCmd = 'SelectWorthOutputting();' + subsetCmd + 'DetachAndRemoveGlyphs();';
+    }
+
     return fontforge(
       source,
-      'Open($1);SetFontNames($3,$3,$3);Generate($2, "", 8);',
+      'Open($1);SetFontNames($3,$3,$3);' + subsetCmd + 'Generate($2, "", 8);',
       target,
       name
     );


### PR DESCRIPTION
Well, this was way, way easier than I anticipated lol
Basically, fontfacegen now accepts a new option, `subset`, which can either be a string or an array. The characters included inside that array/string will be the only ones output, making for very small font files :)
I think the next improvement necessary here would be to refactor to using es6 and the airbnb eslint configuration... but that's something for another day.