### PR TITLE
Programmatic api

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ font to be used in browsers.
 ## Requirements:
 
 - `fontforge`
-- `ttf2eot`
 - `batik-ttf2svg`
 
 ### Installing on OS X
 
-    brew install fontforge ttf2eot batik
+    brew install fontforge batik
 
 ### Other platforms
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ font to be used in browsers.
 ## Requirements:
 
 - `fontforge`
-- `batik-ttf2svg`
 
 ### Installing on OS X
 
-    brew install fontforge batik
+    brew install fontforge
 
 ### Other platforms
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -20,12 +20,6 @@ module.exports = function() {
       fontforge: {}
     };
 
-    if (isLinux) {
-        check.ttf2svg = {};
-    } else {
-        check['batik-ttf2svg'] = {};
-    }
-
     var missing = [];
 
     for (var cmd in check) {
@@ -39,28 +33,12 @@ module.exports = function() {
     }
 
     if (missing.length) {
-        if (isLinux) {
-            var errNPM = [], errAPT = [];
-            missing.forEach(function(cmd){
-                if (cmd.indexOf("ttf2") != -1) {
-                    errNPM.push(cmd);
-                } else{
-                    errAPT.push(cmd);
-                }
-            });
+        var installCmd = isLinux ? 'sudo apt-get install' : 'brew install';
 
-            throw new FontFaceException(
-                'We are missing some required font packages.\n' +
-                'That can be installed with:\n' +
-                (errAPT.length ? 'sudo apt-get install  ' + errAPT.join(' ') + '\n' : '') +
-                (errAPT.length && errNPM.length ? 'and' : '') +
-                (errNPM.length ? 'sudo npm install -g  ' + errNPM.join(' ') : ''));
-        } else {
-            throw new FontFaceException(
-                'We are missing some required font packages.\n' +
-                'That can be installed with:\n' +
-                  'brew install ' + missing.join(' '));
-        }
+        throw new FontFaceException(
+            'We are missing some required font packages.\n' +
+            'That can be installed with:\n' +
+            installCmd + ' ' + missing.join(' '));
     }
 
     return commands;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -17,8 +17,7 @@ module.exports = function() {
     done = true;
 
     var check = {
-      fontforge: {},
-      ttf2eot: {}
+      fontforge: {}
     };
 
     if (isLinux) {

--- a/lib/fontfacegen.js
+++ b/lib/fontfacegen.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
 
     ttf(config.source, config.ttf, config.name, config); // TODO: better options handling
     ttf2eot(config.ttf, config.eot);
-    ttf2svg(config.ttf, config.svg, config.name);
+    ttf2svg(config.ttf, config.svg);
     ttf2woff(config.ttf, config.woff);
     ttf2woff2(config.ttf, config.woff2);
     stylesheets(config);

--- a/lib/ttf2eot.js
+++ b/lib/ttf2eot.js
@@ -2,28 +2,24 @@
 
 var quote = require('./helpers.js').quote;
 var trim = require('./helpers.js').trim;
+var ttf2eot = require('ttf2eot');
+var fs = require('fs');
 var execSync = require('child_process').execSync;
 
 var FontFaceException = require('./exception.js');
 
-var ttf2eotCommand = require('./commands.js').ttf2eot;
-
 module.exports = function(source, dest) {
 
-    var command = [ttf2eotCommand, quote(source), '>', quote(dest)].join(' ');
-
     try {
+        var ttf = new Uint8Array(fs.readFileSync(source));
+        var eot = new Buffer(ttf2eot(ttf).buffer);
 
-        var result = execSync(command).toString();
+        fs.writeFileSync(dest, eot);
 
     } catch (e) {
 
         throw new FontFaceException(
-            'ttf2eot command failed: ' + e.toString() + '\n' +
-            'From command: ' + command + '\n' +
-            trim(result) + '\n' +
+            'eot conversion failed: ' + e.toString() + '\n' +
             'Your EOT file will probably not be in a working state');
     }
-
-    return result;
 };

--- a/lib/ttf2svg.js
+++ b/lib/ttf2svg.js
@@ -2,33 +2,22 @@
 
 var execSync = require('child_process').execSync;
 var quote = require('./helpers.js').quote;
+var ttf2svg = require('ttf2svg');
+var fs = require('fs');
 var trim = require('./helpers.js').trim;
-var isLinux = require('./helpers.js').isLinux();
 
-var commands = require('./commands.js');
+var FontFaceException = require('./exception.js');
 
-module.exports = function(source, target, name) {
+module.exports = function(source, target) {
 
-    var command = '';
-
-    if (isLinux) {
-        command = [commands.ttf2svg, quote(source), '>', quote(target)].join(' ');
-    } else{
-        command = [commands['batik-ttf2svg'], quote(source), '-id', quote(name), '-o', quote(target)].join(' ');
-    }
-    
     try {
-        var result = execSync(command);
-
+        var ttf = fs.readFileSync(source);
+        var svg = ttf2svg(ttf);
+        fs.writeFileSync(target, svg);
 
     } catch (e) {
         throw new FontFaceException(
-            'ttf2svg command failed\n' +
-            'From command: ' + command + '\n' +
-            trim(result) + '\n' +
+            'svg conversion failed: ' + e.toString() + '\n' +
             'Your SVG file will probably not be in a working state');
-        
     }
-
-    return result;
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "mkdirp": "^0.5.1",
     "ttf2eot": "^2.0.0",
+    "ttf2svg": "0.0.7",
     "ttf2woff2": "^2.0.3",
     "which": "^1.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "css"
   ],
   "dependencies": {
-    "ttf2woff2": "^2.0.3",
     "mkdirp": "^0.5.1",
+    "ttf2eot": "^2.0.0",
+    "ttf2woff2": "^2.0.3",
     "which": "^1.2.4"
   }
 }


### PR DESCRIPTION
Stops using `ttf2eot` and `ttf2svg` as commands, opting for their programmatic API, and adds them as `npm` dependencies.

Fixes:

* https://github.com/agentk/fontfacegen/issues/33, as `ttf2svg` works on Linux and Mac (unless we want to support windows too)
* https://github.com/agentk/fontfacegen/issues/32, as no more external dependencies are necessary (except for `fontforge`, but nothing can be done about it as far as I can tell).
* https://github.com/agentk/fontfacegen/issues/23, svg is working properly now