### PR TITLE
Quote fontforge command for Windows support

### DIFF
--- a/src/fontforge.js
+++ b/src/fontforge.js
@@ -23,7 +23,7 @@ function FontForgeException(e, cmd) {
 }
 
 function fontforge(source, script, target, name) {
-  let cmd = `${fontForgeCommand} -lang=ff -c '${script}' '${source}'`;
+  let cmd = `"${fontForgeCommand}" -lang=ff -c '${script}' '${source}'`;
 
   if (target !== undefined) {
     cmd += ` '${target}'`;


### PR DESCRIPTION
This quotes the command name in case it contains spaces.